### PR TITLE
feat: 학과 필터 척척학사 디자인 반영, CCHaksaTheme -> CchTheme, suwikiClickable ->…

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/preview/designsystem/Color.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/preview/designsystem/Color.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
 import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray200
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray300
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray400
@@ -64,7 +65,7 @@ fun ColorItem(
 
         Text(
             text = name,
-            style = CCHaksaTheme.typography.bodyMd,
+            style = CchTheme.typography.bodyMd,
             color = Black100,
             fontSize = 14.sp,
         )
@@ -83,7 +84,7 @@ fun CCHaksaColorPreview() {
         ) {
             Text(
                 text = "Cool Gray",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
                 modifier = Modifier.padding(bottom = 8.dp),
             )
 
@@ -95,7 +96,7 @@ fun CCHaksaColorPreview() {
 
             Text(
                 text = "Purple",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             )
 
@@ -108,7 +109,7 @@ fun CCHaksaColorPreview() {
 
             Text(
                 text = "Red",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             )
 
@@ -119,7 +120,7 @@ fun CCHaksaColorPreview() {
 
             Text(
                 text = "Yellow",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             )
 
@@ -128,7 +129,7 @@ fun CCHaksaColorPreview() {
 
             Text(
                 text = "Green",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             )
 

--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/preview/designsystem/Typography.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/preview/designsystem/Typography.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 
 @Preview(showBackground = true)
 @Composable
@@ -20,52 +21,52 @@ fun CCHaksaTypographyPreview() {
         ) {
             Text(
                 text = "Title ExtraLarge2 (32px)",
-                style = CCHaksaTheme.typography.titleExlg2,
+                style = CchTheme.typography.titleExlg2,
             )
-            
+
             Text(
                 text = "Title ExtraLarge (28px)",
-                style = CCHaksaTheme.typography.titleExlg,
+                style = CchTheme.typography.titleExlg,
             )
-            
+
             Text(
                 text = "Title Large (24px)",
-                style = CCHaksaTheme.typography.titleLg,
+                style = CchTheme.typography.titleLg,
             )
-            
+
             Text(
                 text = "Body ExtraLarge (24px)",
-                style = CCHaksaTheme.typography.bodyExlg,
+                style = CchTheme.typography.bodyExlg,
             )
-            
+
             Text(
                 text = "Body Large Strong (18px)",
-                style = CCHaksaTheme.typography.bodyLgStrong,
+                style = CchTheme.typography.bodyLgStrong,
             )
-            
+
             Text(
                 text = "Body Large (18px)",
-                style = CCHaksaTheme.typography.bodyLg,
+                style = CchTheme.typography.bodyLg,
             )
-            
+
             Text(
                 text = "Body Medium Strong (16px)",
-                style = CCHaksaTheme.typography.bodyMdStrong,
+                style = CchTheme.typography.bodyMdStrong,
             )
-            
+
             Text(
                 text = "Body Medium (16px)",
-                style = CCHaksaTheme.typography.bodyMd,
+                style = CchTheme.typography.bodyMd,
             )
-            
+
             Text(
                 text = "Body Small (14px)",
-                style = CCHaksaTheme.typography.bodySm,
+                style = CchTheme.typography.bodySm,
             )
-            
+
             Text(
                 text = "Body Extra Small (12px)",
-                style = CCHaksaTheme.typography.bodyXs,
+                style = CchTheme.typography.bodyXs,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
@@ -1,9 +1,5 @@
 package com.chukchukhaksa.mobile
 
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
@@ -20,7 +16,6 @@ import chukchukhaksa.composeapp.generated.resources.word_confirm
 import com.chukchukhaksa.mobile.common.designsystem.component.dialog.SuwikiDialog
 import com.chukchukhaksa.mobile.common.designsystem.component.toast.SuwikiToast
 import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
-import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.kmp.SetStatusBarColor
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/ChukChukAppBarWithTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/ChukChukAppBarWithTitle.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import chukchukhaksa.composeapp.generated.resources.Res
 import chukchukhaksa.composeapp.generated.resources.ic_appbar_arrow_left_chukchuk
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -48,7 +48,7 @@ fun ChukChukAppBarWithTitle(
       Text(
         text = title,
         color = Black100,
-        style = CCHaksaTheme.typography.bodyMdStrong,
+        style = CchTheme.typography.bodyMdStrong,
       )
     }
   }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/SuwikiAppBarWithTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/SuwikiAppBarWithTextButton.kt
@@ -21,7 +21,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -47,12 +47,12 @@ fun SuwikiAppBarWithTextButton(
       modifier = Modifier
         .size(24.dp)
         .clip(CircleShape)
-        .suwikiClickable(onClick = onClickBack)
+        .cchClickable(onClick = onClickBack)
         .padding(vertical = 2.dp, horizontal = 6.5.dp),
     )
     Text(
       modifier = Modifier
-        .suwikiClickable(onClick = onClickTextButton)
+        .cchClickable(onClick = onClickTextButton)
         .padding(vertical = 4.dp, horizontal = 8.dp),
       color = Primary,
       style = SuwikiTheme.typography.body6,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/SuwikiAppBarWithTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/SuwikiAppBarWithTitle.kt
@@ -20,7 +20,7 @@ import chukchukhaksa.composeapp.generated.resources.ic_appbar_close_mark
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -45,7 +45,7 @@ fun SuwikiAppBarWithTitle(
           .align(Alignment.CenterStart)
           .size(24.dp)
           .clip(CircleShape)
-          .suwikiClickable(onClick = onClickBack)
+          .cchClickable(onClick = onClickBack)
           .padding(vertical = 2.dp, horizontal = 6.5.dp),
         painter = painterResource(resource = Res.drawable.ic_appbar_arrow_left),
         contentDescription = "",
@@ -67,7 +67,7 @@ fun SuwikiAppBarWithTitle(
           .align(Alignment.CenterEnd)
           .size(24.dp)
           .clip(CircleShape)
-          .suwikiClickable(onClick = onClickClose)
+          .cchClickable(onClick = onClickClose)
           .padding(3.dp),
         painter = painterResource(resource = Res.drawable.ic_appbar_close_mark),
         contentDescription = "",

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/bottomsheet/SuwikiSelectBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/bottomsheet/SuwikiSelectBottomSheet.kt
@@ -22,7 +22,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import kotlinx.collections.immutable.PersistentList
 import org.jetbrains.compose.resources.painterResource
 
@@ -63,7 +63,7 @@ private fun SuwikiSelectContainer(
             .background(White)
             .fillMaxWidth()
             .wrapContentHeight()
-            .suwikiClickable(
+            .cchClickable(
                 onClick = onClick,
                 rippleColor = Gray6A,
             ),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/BasicButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/BasicButton.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun BasicButton(
@@ -45,7 +45,7 @@ fun BasicButton(
                 color = borderColor,
                 shape = shape,
             )
-            .suwikiClickable(
+            .cchClickable(
                 runIf = clickable,
                 rippleColor = rippleColor,
                 onClick = onClick,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/ChukChukBasicButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/ChukChukBasicButton.kt
@@ -3,9 +3,7 @@ package com.chukchukhaksa.mobile.common.designsystem.component.button
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,7 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray300
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray400
 import com.chukchukhaksa.mobile.common.designsystem.theme.White100
@@ -53,7 +51,7 @@ fun ChukChukBasicButton(
           .wrapContentHeight(),
         text = text,
         color = textColor,
-        style = CCHaksaTheme.typography.bodyLgStrong,
+        style = CchTheme.typography.bodyLgStrong,
         textAlign = TextAlign.Center,
       )
   }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/TextFieldClearButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/button/TextFieldClearButton.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.draw.clip
 import chukchukhaksa.composeapp.generated.resources.Res
 import chukchukhaksa.composeapp.generated.resources.ic_textfield_clear
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -19,7 +19,7 @@ fun TextFieldClearButton(
   Icon(
     modifier = modifier
       .clip(CircleShape)
-      .suwikiClickable(onClick = onClick),
+      .cchClickable(onClick = onClick),
     painter = painterResource(resource = Res.drawable.ic_textfield_clear),
     tint = Gray95,
     contentDescription = "",

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/chip/SuwikiOutlinedChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/chip/SuwikiOutlinedChip.kt
@@ -16,7 +16,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.GrayDA
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun SuwikiOutlinedChip(
@@ -34,7 +34,7 @@ fun SuwikiOutlinedChip(
   Box(
     modifier = modifier
       .clip(RoundedCornerShape(5.dp))
-      .suwikiClickable(onClick = onClick)
+      .cchClickable(onClick = onClick)
       .background(color = White)
       .border(width = 1.dp, color = borderLineColor, shape = RoundedCornerShape(5.dp))
       .padding(vertical = 4.dp, horizontal = 6.dp),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/ChukChukSelectionContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/ChukChukSelectionContainer.kt
@@ -4,11 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray200
 import com.chukchukhaksa.mobile.common.designsystem.theme.Purple500
 import com.chukchukhaksa.mobile.common.designsystem.theme.White100
@@ -49,7 +46,7 @@ fun ChukChukSelectionContainer(
       text = text,
       color = textColor,
 //      textAlign = TextAlign.Start,
-      style = CCHaksaTheme.typography.bodyLgStrong,
+      style = CchTheme.typography.bodyLgStrong,
     )
   }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/SuwikiBoardContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/SuwikiBoardContainer.kt
@@ -14,7 +14,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Black
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun SuwikiBoardContainer(
@@ -26,7 +26,7 @@ fun SuwikiBoardContainer(
   Column(
     modifier = modifier
       .fillMaxWidth()
-      .suwikiClickable(onClick = onClick)
+      .cchClickable(onClick = onClick)
       .background(White)
       .padding(24.dp, 15.dp),
   ) {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/SuwikiEditContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/container/SuwikiEditContainer.kt
@@ -24,7 +24,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Black
 import com.chukchukhaksa.mobile.common.designsystem.theme.GrayF6
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -49,7 +49,7 @@ fun SuwikiEditContainer(
                     strokeWidth = strokeWidth,
                 )
             }
-            .suwikiClickable(onClick = onClick)
+            .cchClickable(onClick = onClick)
             .padding(24.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/dialog/SuwikiDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/dialog/SuwikiDialog.kt
@@ -21,7 +21,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun SuwikiDialog(
@@ -61,7 +61,7 @@ fun SuwikiDialog(
                 ) {
                     if (dismissButtonText != null) {
                         Text(
-                            modifier = Modifier.suwikiClickable(
+                            modifier = Modifier.cchClickable(
                                 rippleEnabled = false,
                                 onClick = onClickDismiss
                             ),
@@ -74,7 +74,7 @@ fun SuwikiDialog(
                     Spacer(modifier = Modifier.width(30.dp))
 
                     Text(
-                        modifier = Modifier.suwikiClickable(
+                        modifier = Modifier.cchClickable(
                             rippleEnabled = false,
                             onClick = onClickConfirm
                         ),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/loading/LoadingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/loading/LoadingScreen.kt
@@ -10,12 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
   Box(
-    modifier = modifier.fillMaxSize().suwikiClickable(rippleEnabled = false, onClick = {}),
+    modifier = modifier.fillMaxSize().cchClickable(rippleEnabled = false, onClick = {}),
     contentAlignment = Alignment.Center,
   ) {
     CircularProgressIndicator(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/tabbar/SuwikiTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/tabbar/SuwikiTabBar.kt
@@ -33,7 +33,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Black
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 enum class SubComposeID {
   PRE_CALCULATE_ITEM,
@@ -142,7 +142,7 @@ fun TabTitle(
     modifier = Modifier
       .wrapContentWidth(Alignment.CenterHorizontally)
       .padding(12.dp)
-      .suwikiClickable(
+      .cchClickable(
         rippleEnabled = false,
         onClick = { onClick(position) },
       ),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/CchSearchTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/CchSearchTextField.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray200
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray400
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray600
@@ -91,10 +91,10 @@ object CchSearchTextFieldDefaults {
 fun CchSearchTextField(
   value: String,
   onValueChange: (String) -> Unit,
-  placeholder: String,
   modifier: Modifier = Modifier,
+  placeholder: String? = null,
   enabled: Boolean = true,
-  textStyle: TextStyle = CCHaksaTheme.typography.bodyMd,
+  textStyle: TextStyle = CchTheme.typography.bodyMd,
   colors: CchSearchTextFieldColors = CchSearchTextFieldDefaults.colors(),
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
@@ -142,7 +142,7 @@ fun CchSearchTextField(
         Box(
           modifier = Modifier.weight(1f),
         ) {
-          if (value.isEmpty()) {
+          if (value.isEmpty() && placeholder != null) {
             Text(
               text = placeholder,
               style = textStyle,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/ChukChukRegularTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/ChukChukRegularTextField.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
 import com.chukchukhaksa.mobile.common.designsystem.component.button.TextFieldClearButton
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray200
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray400
 import com.chukchukhaksa.mobile.common.designsystem.theme.Purple600
@@ -35,9 +35,9 @@ fun ChukChukRegularTextField(
   placeholder: String = "",
 ) {
   val (borderColor, textColor, textStyle) = if(value.isEmpty()) {
-    Triple(Gray200, Gray400, CCHaksaTheme.typography.bodyLg)
+    Triple(Gray200, Gray400, CchTheme.typography.bodyLg)
   } else {
-    Triple(Purple600, Black100, CCHaksaTheme.typography.bodyLgStrong)
+    Triple(Purple600, Black100, CchTheme.typography.bodyLgStrong)
   }
   BasicTextField(
     value = value,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/SuwikiRegularTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/SuwikiRegularTextField.kt
@@ -39,7 +39,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.GrayCB
 import com.chukchukhaksa.mobile.common.designsystem.theme.GrayF6
 import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -133,7 +133,7 @@ fun SuwikiRegularTextField(
                                     modifier = modifier
                                         .size(24.dp)
                                         .clip(CircleShape)
-                                        .suwikiClickable(onClick = onClickEyeIcon),
+                                        .cchClickable(onClick = onClickEyeIcon),
                                     painter = painterResource(resource = if (showValue) Res.drawable.ic_eye_off else Res.drawable.ic_eye_on),
                                     tint = Gray95,
                                     contentDescription = "",

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/theme/Theme.kt
@@ -45,7 +45,7 @@ object SuwikiTheme {
     get() = LocalTypography.current
 }
 
-object CCHaksaTheme {
+object CchTheme {
   val typography: CCHaksaTypography
     @Composable
     @ReadOnlyComposable

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/ui/Modifier.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/ui/Modifier.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.Color
  *
  * @return clickable 이 적용된 [Modifier]
  */
-fun Modifier.suwikiClickable(
+fun Modifier.cchClickable(
   rippleEnabled: Boolean = true,
   rippleColor: Color? = null,
   runIf: Boolean = true,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/celleditor/CellEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/celleditor/CellEditorScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -65,7 +64,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.model.TimetableCellColor
 import com.chukchukhaksa.mobile.common.model.TimetableDay
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import com.chukchukhaksa.mobile.common.ui.timetableCellColorHexMap
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.timetable.toText
 import org.jetbrains.compose.resources.getString
@@ -287,7 +286,7 @@ fun CellEditorScreen(
                                             .aspectRatio(1f)
                                             .clip(CircleShape)
                                             .background(Color(timetableCellColorHexMap[it]!!))
-                                            .suwikiClickable(
+                                            .cchClickable(
                                                 rippleEnabled = false,
                                                 onClick = { onClickColorChip(it) },
                                             ),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/OpenLectureScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/OpenLectureScreen.kt
@@ -62,7 +62,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.model.OpenLecture
 import com.chukchukhaksa.mobile.common.model.TimetableCellColor
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import com.chukchukhaksa.mobile.common.ui.timetableCellColorHexMap
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.bottomsheet.openmajor.OpenMajorBottomSheet
 import com.chukchukhaksa.mobile.presentation.timetable.navigation.argument.CellEditorArgument
@@ -337,7 +337,7 @@ private fun ColorSelectBottomSheet(
               .aspectRatio(1f)
               .clip(CircleShape)
               .background(Color(timetableCellColorHexMap[it]!!))
-              .suwikiClickable(
+              .cchClickable(
                 rippleEnabled = false,
                 onClick = { onClickColorChip(it) },
               ),
@@ -372,7 +372,7 @@ private fun FilterContainer(
     modifier = Modifier
       .clip(RoundedCornerShape(size = 10.dp))
       .border(width = 1.dp, color = GrayF6, shape = RoundedCornerShape(size = 10.dp))
-      .suwikiClickable(onClick = onClick)
+      .cchClickable(onClick = onClick)
       .padding(vertical = 6.dp, horizontal = 9.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/component/OpenLectureCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/component/OpenLectureCard.kt
@@ -28,7 +28,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.GrayDA
 import com.chukchukhaksa.mobile.common.designsystem.theme.GrayF6
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -56,7 +56,7 @@ fun OpenLectureCard(
                     strokeWidth = strokeWidth,
                 )
             }
-            .suwikiClickable(
+            .cchClickable(
                 onClick = onClick,
             )
             .padding(horizontal = 24.dp, vertical = 16.dp),

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/semesterselect/SemesterSelectScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/semesterselect/SemesterSelectScreen.kt
@@ -4,13 +4,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -24,8 +20,7 @@ import com.chukchukhaksa.mobile.common.designsystem.component.SuwikiBackground
 import com.chukchukhaksa.mobile.common.designsystem.component.appbar.ChukChukAppBarWithTitle
 import com.chukchukhaksa.mobile.common.designsystem.component.button.ChukChukBasicButton
 import com.chukchukhaksa.mobile.common.designsystem.component.container.ChukChukSelectionContainer
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
-import com.chukchukhaksa.mobile.common.designsystem.theme.GrayFB
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import com.chukchukhaksa.mobile.presentation.timetable.navigation.argument.TimetableEditorArgument
 import kotlinx.collections.immutable.toPersistentList
@@ -73,7 +68,7 @@ fun SemesterSelectScreen(
           modifier = Modifier.padding(top = 20.dp, bottom = 32.dp),
           text = "수강학기를 선택해주세요",
           textAlign = TextAlign.Center,
-          style = CCHaksaTheme.typography.titleLg,
+          style = CchTheme.typography.titleLg,
         )
 
         Column(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/TimetableAppbar.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/TimetableAppbar.kt
@@ -22,7 +22,7 @@ import chukchukhaksa.composeapp.generated.resources.word_timetable
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -59,7 +59,7 @@ fun TimetableAppbar(
         Icon(
             modifier = Modifier
                 .clip(CircleShape)
-                .suwikiClickable(onClick = onClickAdd),
+                .cchClickable(onClick = onClickAdd),
             painter = painterResource(Res.drawable.ic_timetable_add),
             contentDescription = "",
             tint = Gray95,
@@ -68,7 +68,7 @@ fun TimetableAppbar(
         Icon(
             modifier = Modifier
                 .clip(CircleShape)
-                .suwikiClickable(onClick = onClickHamburger),
+                .cchClickable(onClick = onClickHamburger),
             painter = painterResource(Res.drawable.ic_timetable_hamburger),
             contentDescription = "",
             tint = Gray95,
@@ -77,7 +77,7 @@ fun TimetableAppbar(
         Icon(
             modifier = Modifier
                 .clip(CircleShape)
-                .suwikiClickable(onClick = onClickSetting),
+                .cchClickable(onClick = onClickSetting),
             painter = painterResource(Res.drawable.ic_timetable_setting),
             contentDescription = "",
             tint = Gray95,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorBottomSheet.kt
@@ -2,10 +2,9 @@ package com.chukchukhaksa.mobile.presentation.timetable.timetable.component.bott
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -19,23 +18,18 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import chukchukhaksa.composeapp.generated.resources.Res
 import chukchukhaksa.composeapp.generated.resources.open_major_empty_search_result
 import chukchukhaksa.composeapp.generated.resources.open_major_screen_search_bar_placeholder
-import chukchukhaksa.composeapp.generated.resources.word_confirm
 import com.chukchukhaksa.mobile.common.designsystem.component.bottomsheet.CchBottomSheet
-import com.chukchukhaksa.mobile.common.designsystem.component.button.SuwikiContainedLargeButton
 import com.chukchukhaksa.mobile.common.designsystem.component.loading.LoadingScreen
-import com.chukchukhaksa.mobile.common.designsystem.component.searchbar.SuwikiSearchBar
+import com.chukchukhaksa.mobile.common.designsystem.component.textfield.CchSearchTextField
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray95
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
-import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
-import com.chukchukhaksa.mobile.common.ui.shadow.suwikiShadow
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.bottomsheet.openmajor.model.OpenMajor
 import kotlinx.collections.immutable.PersistentList
 import org.jetbrains.compose.resources.stringResource
@@ -53,147 +47,126 @@ fun OpenMajorBottomSheet(
   handleException: (Throwable) -> Unit,
   onShowToast: (String) -> Unit,
 ) {
-    val uiState by viewModel.mviStore.uiState.collectAsStateWithLifecycle()
+  val uiState by viewModel.mviStore.uiState.collectAsStateWithLifecycle()
 
-    viewModel.mviStore.sideEffects.collectWithLifecycle { sideEffect ->
-        when (sideEffect) {
-            is OpenMajorSideEffect.HandleException -> handleException(sideEffect.throwable)
-            OpenMajorSideEffect.PopBackStack -> onDismissRequest()
-            is OpenMajorSideEffect.PopBackStackWithArgument -> onConfirm(sideEffect.argument)
-        }
+  viewModel.mviStore.sideEffects.collectWithLifecycle { sideEffect ->
+    when (sideEffect) {
+      is OpenMajorSideEffect.HandleException -> handleException(sideEffect.throwable)
+      OpenMajorSideEffect.PopBackStack -> onDismissRequest()
+      is OpenMajorSideEffect.PopBackStackWithArgument -> onConfirm(sideEffect.argument)
     }
+  }
 
 
-    val allOpenMajorListState = rememberLazyListState()
+  val allOpenMajorListState = rememberLazyListState()
 
-    val onReachedBottomAllOpenMajor by remember {
-        derivedStateOf {
-            allOpenMajorListState.isScrolledToEnd()
-        }
+  val onReachedBottomAllOpenMajor by remember {
+    derivedStateOf {
+      allOpenMajorListState.isScrolledToEnd()
     }
+  }
 
-    LaunchedEffect(onReachedBottomAllOpenMajor) {
-        viewModel.changeBottomShadowVisible(!onReachedBottomAllOpenMajor)
-    }
+  LaunchedEffect(onReachedBottomAllOpenMajor) {
+    viewModel.changeBottomShadowVisible(!onReachedBottomAllOpenMajor)
+  }
 
-    LaunchedEffect(selectedOpenMajor) {
-        viewModel.setInitialSelectedOpenMajor(selectedOpenMajor)
-    }
+  LaunchedEffect(selectedOpenMajor) {
+    viewModel.setInitialSelectedOpenMajor(selectedOpenMajor)
+  }
 
-    LaunchedEffect(key1 = Unit) {
-        viewModel.initData()
-    }
+  LaunchedEffect(key1 = Unit) {
+    viewModel.initData()
+  }
 
-    CchBottomSheet(
-        onDismissRequest = onDismissRequest,
-    ) {
-        OpenMajorBottomSheetContent(
-            uiState = uiState,
-            allOpenMajorListState = allOpenMajorListState,
-            onClickConfirmButton = viewModel::popBackStackWithArgument,
-            onClickOpenMajorContainer = viewModel::updateSelectedOpenMajor,
-            onValueChangeSearchBar = viewModel::updateSearchValue,
-            onClickSearchBarClearButton = { viewModel.updateSearchValue("") },
-        )
-    }
+  CchBottomSheet(
+    onDismissRequest = onDismissRequest,
+  ) {
+    OpenMajorBottomSheetContent(
+      uiState = uiState,
+      allOpenMajorListState = allOpenMajorListState,
+      onClickOpenMajorContainer = viewModel::updateSelectedOpenMajor,
+      onValueChangeSearchBar = viewModel::updateSearchValue,
+    )
+  }
 }
 
 @Composable
 private fun OpenMajorBottomSheetContent(
   uiState: OpenMajorState = OpenMajorState(),
   allOpenMajorListState: LazyListState = rememberLazyListState(),
-  onClickConfirmButton: () -> Unit = {},
   onClickOpenMajorContainer: (String) -> Unit = {},
   onValueChangeSearchBar: (String) -> Unit = {},
-  onClickSearchBarClearButton: () -> Unit = {},
 ) {
-    Column(
-        modifier = Modifier.height(400.dp), // TODO 척척학사 디자인 반영하면서 매직 넘버 제거 예정 (@이진욱)
-    ) {
-        SuwikiSearchBar(
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
-            placeholder = stringResource(Res.string.open_major_screen_search_bar_placeholder),
-            value = uiState.searchValue,
-            onClickClearButton = onClickSearchBarClearButton,
-            onValueChange = onValueChangeSearchBar,
-        )
+  Column {
+    CchSearchTextField(
+      modifier = Modifier.padding(horizontal = 20.dp),
+      value = uiState.searchValue,
+      onValueChange = onValueChangeSearchBar,
+      placeholder = stringResource(Res.string.open_major_screen_search_bar_placeholder),
+    )
 
-        if (uiState.showAllOpenMajorEmptySearchResultScreen) {
-            EmptyText(stringResource(Res.string.open_major_empty_search_result))
-        } else {
-            OpenMajorLazyColumn(
-                modifier = Modifier.weight(1f),
-                listState = allOpenMajorListState,
-                openMajorList = uiState.filteredAllOpenMajorList,
-                onClickOpenMajorContainer = onClickOpenMajorContainer,
-            )
-        }
+    Spacer(Modifier.height(8.dp))
 
-        Box(
-            modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 24.dp),
-        ) {
-            SuwikiContainedLargeButton(
-                modifier = Modifier
-                    .imePadding()
-                    .suwikiShadow(
-                        color = if (uiState.showBottomShadow) White else Color.Transparent,
-                        blurRadius = 80.dp,
-                        spread = 50.dp,
-                    ),
-                text = stringResource(Res.string.word_confirm),
-                onClick = onClickConfirmButton,
-            )
-        }
+    if (uiState.showAllOpenMajorEmptySearchResultScreen) {
+      EmptyText(stringResource(Res.string.open_major_empty_search_result))
+    } else {
+      OpenMajorLazyColumn(
+        listState = allOpenMajorListState,
+        openMajorList = uiState.filteredAllOpenMajorList,
+        searchValue = uiState.searchValue,
+        onClickOpenMajorContainer = onClickOpenMajorContainer,
+      )
     }
+  }
 
-    if (uiState.isLoading) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            LoadingScreen()
-        }
+  if (uiState.isLoading) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      LoadingScreen()
     }
+  }
 }
 
 @Composable
 private fun EmptyText(
-    text: String = "",
+  text: String = "",
 ) {
-    Text(
-        modifier = Modifier
-            .padding(52.dp)
-            .fillMaxSize(),
-        textAlign = TextAlign.Center,
-        text = text,
-        style = SuwikiTheme.typography.header4,
-        color = Gray95,
-    )
+  Text(
+    modifier = Modifier
+      .padding(52.dp)
+      .fillMaxSize(),
+    textAlign = TextAlign.Center,
+    text = text,
+    style = SuwikiTheme.typography.header4,
+    color = Gray95,
+  )
 }
 
 @OptIn(ExperimentalUuidApi::class)
 @Composable
 private fun OpenMajorLazyColumn(
-    modifier: Modifier = Modifier,
-    listState: LazyListState,
-    openMajorList: PersistentList<OpenMajor>,
-    onClickOpenMajorContainer: (String) -> Unit = {},
+  modifier: Modifier = Modifier,
+  listState: LazyListState,
+  openMajorList: PersistentList<OpenMajor>,
+  searchValue: String = "",
+  onClickOpenMajorContainer: (String) -> Unit = {},
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        state = listState,
-        contentPadding = PaddingValues(top = 12.dp),
-    ) {
-        items(
-            items = openMajorList,
-            key = { it.id },
-        ) { openMajor ->
-            with(openMajor) {
-                OpenMajorItem(
-                    text = name,
-                    isChecked = isSelected,
-                    onClick = { onClickOpenMajorContainer(name) },
-                )
-            }
-        }
+  LazyColumn(
+    modifier = modifier.height(56.dp * 5),
+    state = listState,
+  ) {
+    items(
+      items = openMajorList,
+      key = { it.id },
+    ) { openMajor ->
+      with(openMajor) {
+        OpenMajorItem(
+          text = name,
+          searchValue = searchValue,
+          onClick = { onClickOpenMajorContainer(name) },
+        )
+      }
     }
+  }
 }
 
 //@OptIn(ExperimentalFoundationApi::class)
@@ -206,5 +179,5 @@ private fun OpenMajorLazyColumn(
 //}
 
 fun LazyListState.isScrolledToEnd() =
-    layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1
+  layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1
 

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorBottomSheetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorBottomSheetViewModel.kt
@@ -13,65 +13,60 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class OpenMajorBottomSheetViewModel(
-    private val getOpenMajorListUseCase: GetOpenMajorListUseCase,
-    private val openLectureRepository: OpenLectureRepository,
-    savedStateHandle: SavedStateHandle,
+  private val getOpenMajorListUseCase: GetOpenMajorListUseCase,
+  private val openLectureRepository: OpenLectureRepository,
 ) : ViewModel() {
-    val mviStore: MviStore<OpenMajorState, OpenMajorSideEffect> = mviStore(OpenMajorState())
+  val mviStore: MviStore<OpenMajorState, OpenMajorSideEffect> = mviStore(OpenMajorState())
 
-    private var selectedOpenMajor = "전체"
-    private val allOpenMajorList = mutableListOf<String>()
+  private var selectedOpenMajor = "전체"
+  private val allOpenMajorList = mutableListOf<String>()
 
-    fun updateSearchValue(searchValue: String) {
-        mviStore.setState { copy(searchValue = searchValue) }
-        reduceOpenMajorList(searchValue)
+  fun updateSearchValue(searchValue: String) {
+    mviStore.setState { copy(searchValue = searchValue) }
+    reduceOpenMajorList(searchValue)
+  }
+
+  fun updateSelectedOpenMajor(openMajor: String) {
+    selectedOpenMajor = openMajor
+    mviStore.postSideEffect(OpenMajorSideEffect.PopBackStackWithArgument(selectedOpenMajor))
+  }
+
+  fun popBackStack() {
+    mviStore.postSideEffect(OpenMajorSideEffect.PopBackStack)
+  }
+
+  fun changeBottomShadowVisible(show: Boolean) {
+    mviStore.setState { copy(showBottomShadow = show) }
+  }
+
+  fun setInitialSelectedOpenMajor(initialSelectedOpenMajor: String) {
+    selectedOpenMajor = initialSelectedOpenMajor
+  }
+
+  fun initData() {
+    mviStore.setState { copy(isLoading = true) }
+    getOpenMajor()
+    mviStore.setState { copy(isLoading = false) }
+  }
+
+  private fun getOpenMajor() {
+    getOpenMajorListUseCase().onEach {
+      allOpenMajorList.clear()
+      val firebaseOpenMajor = openLectureRepository.getOpenMajor()
+      allOpenMajorList.addAll((it + firebaseOpenMajor).distinct())
+      reduceOpenMajorList()
+    }.catch {
+    }.launchIn(viewModelScope)
+  }
+
+  private fun reduceOpenMajorList(searchValue: String = mviStore.uiState.value.searchValue) {
+    mviStore.setState {
+      copy(
+        filteredAllOpenMajorList = allOpenMajorList.toOpenMajorList(
+          searchValue = searchValue,
+          selectedOpenMajor = selectedOpenMajor,
+        ),
+      )
     }
-
-    fun updateSelectedOpenMajor(openMajor: String) {
-        selectedOpenMajor = openMajor
-        reduceOpenMajorList()
-    }
-
-    fun popBackStack() {
-        mviStore.postSideEffect(OpenMajorSideEffect.PopBackStack)
-    }
-
-    fun popBackStackWithArgument() {
-        mviStore.postSideEffect(OpenMajorSideEffect.PopBackStackWithArgument(selectedOpenMajor))
-    }
-
-    fun changeBottomShadowVisible(show: Boolean) {
-        mviStore.setState { copy(showBottomShadow = show) }
-    }
-
-    fun setInitialSelectedOpenMajor(initialSelectedOpenMajor: String) {
-        selectedOpenMajor = initialSelectedOpenMajor
-    }
-
-    fun initData() {
-        mviStore.setState { copy(isLoading = true) }
-        getOpenMajor()
-        mviStore.setState{ copy(isLoading = false) }
-    }
-
-    private fun getOpenMajor() {
-        getOpenMajorListUseCase().onEach {
-            allOpenMajorList.clear()
-            val firebaseOpenMajor = openLectureRepository.getOpenMajor()
-            allOpenMajorList.addAll((it + firebaseOpenMajor).distinct())
-            reduceOpenMajorList()
-        }.catch {
-        }.launchIn(viewModelScope)
-    }
-
-    private fun reduceOpenMajorList(searchValue: String = mviStore.uiState.value.searchValue) {
-        mviStore.setState {
-                copy(
-                    filteredAllOpenMajorList = allOpenMajorList.toOpenMajorList(
-                        searchValue = searchValue,
-                        selectedOpenMajor = selectedOpenMajor,
-                    ),
-                )
-            }
-    }
+  }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/bottomsheet/openmajor/OpenMajorItem.kt
@@ -1,6 +1,5 @@
 package com.chukchukhaksa.mobile.presentation.timetable.timetable.component.bottomsheet.openmajor
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,45 +8,39 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.chukchukhaksa.mobile.common.designsystem.theme.Black
-import com.chukchukhaksa.mobile.common.designsystem.theme.Blue5
-import com.chukchukhaksa.mobile.common.designsystem.theme.Primary
-import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
-import com.chukchukhaksa.mobile.common.designsystem.theme.White
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.Purple600
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 
 @Composable
 fun OpenMajorItem(
-    modifier: Modifier = Modifier,
-    text: String,
-    isChecked: Boolean,
-    onClick: () -> Unit = {},
+  modifier: Modifier = Modifier,
+  text: String,
+  searchValue: String = "",
+  onClick: () -> Unit = {},
 ) {
-    val (textColor, backgroundColor) = if (isChecked) {
-        Primary to Blue5
-    } else {
-        Black to White
-    }
-
-    Row(
-        modifier = modifier
-            .background(backgroundColor)
-            .padding(vertical = 12.dp, horizontal = 24.dp)
-            .fillMaxWidth()
-            .suwikiClickable(
-                rippleEnabled = false,
-                onClick = onClick,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Start,
-    ) {
-        Text(
-            text = text,
-            style = SuwikiTheme.typography.body2,
-            color = textColor,
-        )
-    }
+  Row(
+    modifier = modifier
+      .cchClickable(
+        onClick = onClick,
+      )
+      .padding(vertical = 16.dp, horizontal = 20.dp)
+      .fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.Start,
+  ) {
+    Text(
+      text = buildHighlightedText(text, searchValue),
+      style = CchTheme.typography.bodyMdStrong,
+      color = Black100,
+    )
+  }
 }
 
 //@Preview(widthDp = 300, heightDp = 50)
@@ -63,3 +56,39 @@ fun OpenMajorItem(
 //        )
 //    }
 //}
+
+@Composable
+private fun buildHighlightedText(
+  text: String,
+  searchValue: String,
+): AnnotatedString {
+  return if (searchValue.isEmpty()) {
+    AnnotatedString(text)
+  } else {
+    buildAnnotatedString {
+      val lowerText = text.lowercase()
+      val lowerSearchValue = searchValue.lowercase()
+      var startIndex = 0
+      
+      while (startIndex < text.length) {
+        val index = lowerText.indexOf(lowerSearchValue, startIndex)
+        if (index == -1) {
+          append(text.substring(startIndex))
+          break
+        }
+        
+        // Add text before match
+        if (index > startIndex) {
+          append(text.substring(startIndex, index))
+        }
+        
+        // Add highlighted match
+        withStyle(style = SpanStyle(color = Purple600)) {
+          append(text.substring(index, index + searchValue.length))
+        }
+        
+        startIndex = index + searchValue.length
+      }
+    }
+  }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/timetable/cell/ClassCell.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/timetable/cell/ClassCell.kt
@@ -17,7 +17,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.model.TimetableCell
 import com.chukchukhaksa.mobile.common.model.TimetableCellColor
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import com.chukchukhaksa.mobile.common.ui.timetableCellColorHexMap
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.timetable.timetableBorderWidth
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.timetable.timetableHeightPerHour
@@ -62,7 +62,7 @@ fun ClassCell(
             .border(width = timetableBorderWidth, color = GrayF6)
             .padding(timetableBorderWidth)
             .background(Color(data.color.toHex()))
-            .suwikiClickable {
+            .cchClickable {
                 onClick(data)
             },
     ) {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/timetable/cell/ELearningCell.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/timetable/cell/ELearningCell.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.chukchukhaksa.mobile.common.model.TimetableCell
-import com.chukchukhaksa.mobile.common.ui.suwikiClickable
+import com.chukchukhaksa.mobile.common.ui.cchClickable
 import com.chukchukhaksa.mobile.presentation.timetable.timetable.component.timetable.toText
 
 @Composable
@@ -25,7 +25,7 @@ internal fun ELearningCell(
     EmptyCell(
         modifier = modifier
             .fillMaxWidth()
-            .suwikiClickable {
+            .cchClickable {
                 onClickClassCell(cell)
             },
         text = text,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
@@ -26,7 +26,7 @@ import com.chukchukhaksa.mobile.common.designsystem.component.appbar.ChukChukApp
 import com.chukchukhaksa.mobile.common.designsystem.component.button.ChukChukBasicButton
 import com.chukchukhaksa.mobile.common.designsystem.component.textfield.ChukChukRegularTextField
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
-import com.chukchukhaksa.mobile.common.designsystem.theme.CCHaksaTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import org.jetbrains.compose.resources.getString
@@ -89,7 +89,7 @@ fun TimetableEditorScreen(
                     .width(240.dp)
                     .padding(top = 8.dp),
                   text = "선택한 학기의 시간표 이름을 정해주세요",
-                  style = CCHaksaTheme.typography.titleLg,
+                  style = CchTheme.typography.titleLg,
                   color = Black100,
                   textAlign = TextAlign.Center,
                 )


### PR DESCRIPTION
… cchClickable

## 📌 PR 요약

🌱 작업한 내용
- 학과 필터 척척학사 디자인 반영

🌱 PR 포인트
- #15 PR을 먼저 봐주세요.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="540" height="1320" alt="image" src="https://github.com/user-attachments/assets/fa5e8487-fb0b-44cc-abbf-b9e9b7535c28" />|

## 📮 관련 이슈
- Resolved: #16 

### RCA 룰을 사용하여 코드 리뷰를 해주세요
`R (Request Changes)` : 적극적으로 반영을 고려해주세요   
`C (Comment)` : 웬만하면 반영해주세요   
`A (Approve)` : 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 테마와 타이포그래피 적용 방식을 `CCHaksaTheme`에서 `CchTheme`로 일괄 변경하였습니다.
  * 커스텀 클릭 모디파이어를 `suwikiClickable`에서 `cchClickable`로 통일하였습니다.
  * 일부 미사용 import 및 불필요한 코드가 정리되었습니다.
  * 전공 선택 바텀시트에서 확인 버튼이 제거되고, 검색어 하이라이트 기능이 추가되었습니다.
  * 검색 입력 필드의 placeholder가 선택적으로 표시되도록 개선되었습니다.

* **New Features**
  * 전공 리스트에서 검색어와 일치하는 부분이 하이라이트되어 표시됩니다.

* **Bug Fixes**
  * 일부 UI 요소에서 클릭 영역 및 스타일 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->