### PR TITLE
Feature/#30 feat timetable name limit

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/CchAppBarWithTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/appbar/CchAppBarWithTitle.kt
@@ -43,12 +43,14 @@ fun CchAppBarWithTitle(
     Row(
       modifier = Modifier
         .wrapContentWidth()
-        .height(24.dp)
-        .clickable { onClickBackButton() },
+        .height(24.dp),
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
       Image(
+        modifier = Modifier
+          .clip(CircleShape)
+          .cchClickable(onClick = onClickBackButton),
         painter = painterResource(resource = Res.drawable.ic_appbar_arrow_left_chukchuk),
         contentDescription = "",
       )

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/CchRegularTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/designsystem/component/textfield/CchRegularTextField.kt
@@ -24,6 +24,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray200
 import com.chukchukhaksa.mobile.common.designsystem.theme.Gray400
 import com.chukchukhaksa.mobile.common.designsystem.theme.Purple600
+import com.chukchukhaksa.mobile.common.designsystem.theme.Red300
 import com.chukchukhaksa.mobile.common.designsystem.theme.White100
 
 @Composable
@@ -32,13 +33,14 @@ fun CchRegularTextField(
   value: String = "",
   placeholder: String = "",
   isActive: Boolean = false,
+  isError: Boolean = false,
   onValueChanged: (String) -> Unit = {},
   onClickClearButton: () -> Unit = {}
 ) {
   val (borderColor, textColor, textStyle) = if(!isActive) {
     Triple(Gray200, Gray400, CchTheme.typography.bodyLg)
   } else {
-    Triple(Purple600, Black100, CchTheme.typography.bodyLgStrong)
+    Triple(if (isError) Red300 else Purple600, Black100, CchTheme.typography.bodyLgStrong)
   }
   BasicTextField(
     value = value,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/extension/TimetableNameLimit.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/extension/TimetableNameLimit.kt
@@ -1,0 +1,11 @@
+package com.chukchukhaksa.mobile.common.extension
+
+const val TIMETABLE_NAME_LIMIT = 20
+
+fun checkOverTimetableNameLimit(name: String): Boolean {
+    return name.trim().length > TIMETABLE_NAME_LIMIT
+}
+
+fun checkTimetableNameRule(name: String): Boolean {
+    return name.isNotBlank() && name.trim().length <= TIMETABLE_NAME_LIMIT
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorContract.kt
@@ -13,7 +13,7 @@ data class TimetableEditorState(
     val selectedSemesterPosition: Int? = null,
 ) {
     val semester = selectedSemesterPosition?.let { semesterList.getOrNull(it) }
-    val buttonEnabled = (name.isNotEmpty() && preName != name || preSelectedSemesterPosition != selectedSemesterPosition)
+    val buttonEnabled = ((name.isNotEmpty() && name.length <= 20) && (preName != name || preSelectedSemesterPosition != selectedSemesterPosition))
 }
 
 internal fun TimetableEditorArgument.toState() = TimetableEditorState(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorContract.kt
@@ -3,6 +3,7 @@ package com.chukchukhaksa.mobile.presentation.timetable.timetableeditor
 import com.chukchukhaksa.mobile.presentation.timetable.navigation.argument.TimetableEditorArgument
 import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.semesterList
 import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.Semester
+import com.chukchukhaksa.mobile.common.extension.checkTimetableNameRule
 
 
 data class TimetableEditorState(
@@ -13,7 +14,7 @@ data class TimetableEditorState(
     val selectedSemesterPosition: Int? = null,
 ) {
     val semester = selectedSemesterPosition?.let { semesterList.getOrNull(it) }
-    val buttonEnabled = ((name.isNotEmpty() && name.length <= 20) && (preName != name || preSelectedSemesterPosition != selectedSemesterPosition))
+    val buttonEnabled = ((checkTimetableNameRule(name)) && (preName != name || preSelectedSemesterPosition != selectedSemesterPosition))
 }
 
 internal fun TimetableEditorArgument.toState() = TimetableEditorState(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
@@ -29,6 +29,7 @@ import com.chukchukhaksa.mobile.common.designsystem.component.textfield.CchRegul
 import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Red300
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
+import com.chukchukhaksa.mobile.common.extension.checkOverTimetableNameLimit
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.semesterList
 import kotlinx.collections.immutable.toPersistentList
@@ -105,7 +106,7 @@ fun TimetableEditorScreen(
                     value = uiState.name,
                     placeholder = stringResource(Res.string.create_timetable_screen_placeholder),
                     isActive = uiState.name.isNotEmpty() && uiState.name != uiState.preName,
-                    isError = uiState.name.length > 20,
+                    isError = checkOverTimetableNameLimit(uiState.name),
                     onValueChanged = onValueChangeTimetableName,
                     onClickClearButton = onClickTextFieldClearButton,
                 )

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetableeditor/TimetableEditorScreen.kt
@@ -6,12 +6,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -23,6 +26,8 @@ import com.chukchukhaksa.mobile.common.designsystem.component.bottomsheet.CchSel
 import com.chukchukhaksa.mobile.common.designsystem.component.button.CchBasicButton
 import com.chukchukhaksa.mobile.common.designsystem.component.container.CchSelectionButton
 import com.chukchukhaksa.mobile.common.designsystem.component.textfield.CchRegularTextField
+import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.Red300
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.semesterList
@@ -100,9 +105,22 @@ fun TimetableEditorScreen(
                     value = uiState.name,
                     placeholder = stringResource(Res.string.create_timetable_screen_placeholder),
                     isActive = uiState.name.isNotEmpty() && uiState.name != uiState.preName,
+                    isError = uiState.name.length > 20,
                     onValueChanged = onValueChangeTimetableName,
                     onClickClearButton = onClickTextFieldClearButton,
                 )
+
+                if (uiState.name.length > 20) {
+                  Text(
+                    modifier = Modifier
+                      .padding(top = 12.dp, start = 4.dp, end = 4.dp)
+                      .fillMaxWidth(),
+                    text = "시간표 이름은 최대 20자까지 설정 가능합니다.",
+                    textAlign = TextAlign.Start,
+                    style = CchTheme.typography.bodyMd,
+                    color = Red300,
+                  )
+                }
 
                 Spacer(modifier = Modifier.weight(1f))
 

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablelist/TimetableListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablelist/TimetableListScreen.kt
@@ -104,9 +104,9 @@ fun TimetableListScreen(
             if (uiState.timetableList.isEmpty()) {
                 Text(
                     modifier = Modifier
-                        .padding(top = 150.dp),
+                        .padding(top = 324.dp),
                     textAlign = TextAlign.Center,
-                    text = stringResource(Res.string.timetable_list_screen_empty_timetable),
+                    text = "등록된 시간표가 없어요!",
                     style = CchTheme.typography.bodyMd,
                     color = Gray600,
                 )

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputContract.kt
@@ -1,7 +1,7 @@
 package com.chukchukhaksa.mobile.presentation.timetable.timetablenameinput
 
+import com.chukchukhaksa.mobile.common.extension.checkTimetableNameRule
 import com.chukchukhaksa.mobile.presentation.timetable.navigation.argument.TimetableEditorArgument
-import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.semesterList
 import com.chukchukhaksa.mobile.presentation.timetable.semesterselect.Semester
 
 
@@ -9,7 +9,7 @@ data class TimetableNameInputState(
     val name: String = "",
     val semester: Semester = Semester("", "")
 ) {
-    val buttonEnabled = name.isNotEmpty() && name.length <= 20
+    val buttonEnabled = checkTimetableNameRule(name)
 }
 
 internal fun TimetableEditorArgument.toState() = TimetableNameInputState(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputContract.kt
@@ -9,7 +9,7 @@ data class TimetableNameInputState(
     val name: String = "",
     val semester: Semester = Semester("", "")
 ) {
-    val buttonEnabled = name.isNotEmpty()
+    val buttonEnabled = name.isNotEmpty() && name.length <= 20
 }
 
 internal fun TimetableEditorArgument.toState() = TimetableNameInputState(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -28,6 +29,7 @@ import com.chukchukhaksa.mobile.common.designsystem.component.button.CchBasicBut
 import com.chukchukhaksa.mobile.common.designsystem.component.textfield.CchRegularTextField
 import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
 import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
+import com.chukchukhaksa.mobile.common.designsystem.theme.Red300
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import org.jetbrains.compose.resources.getString
@@ -102,9 +104,22 @@ fun TimetableNameInputScreen(
                     value = uiState.name,
                     placeholder = stringResource(Res.string.create_timetable_screen_placeholder),
                     isActive = uiState.name.isNotEmpty(),
+                    isError = uiState.name.length > 20,
                     onValueChanged = onValueChangeTimetableName,
                     onClickClearButton = onClickTextFieldClearButton,
                 )
+
+                if (uiState.name.length > 20) {
+                  Text(
+                    modifier = Modifier
+                      .padding(top = 12.dp, start = 4.dp, end = 4.dp)
+                      .fillMaxWidth(),
+                    text = "시간표 이름은 최대 20자까지 설정 가능합니다.",
+                    textAlign = TextAlign.Start,
+                    style = CchTheme.typography.bodyMd,
+                    color = Red300,
+                  )
+                }
 
                 Spacer(modifier = Modifier.weight(1f))
 

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetablenameinput/TimetableNameInputScreen.kt
@@ -31,6 +31,7 @@ import com.chukchukhaksa.mobile.common.designsystem.theme.Black100
 import com.chukchukhaksa.mobile.common.designsystem.theme.CchTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.Red300
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
+import com.chukchukhaksa.mobile.common.extension.checkOverTimetableNameLimit
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
@@ -104,7 +105,7 @@ fun TimetableNameInputScreen(
                     value = uiState.name,
                     placeholder = stringResource(Res.string.create_timetable_screen_placeholder),
                     isActive = uiState.name.isNotEmpty(),
-                    isError = uiState.name.length > 20,
+                    isError = checkOverTimetableNameLimit(uiState.name),
                     onValueChanged = onValueChangeTimetableName,
                     onClickClearButton = onClickTextFieldClearButton,
                 )


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 시간표 이름 20자 제한 기능 추가
-  CchAppBarWithTitle "뒤로 가기" 버튼 영역 수정

🌱 PR 포인트
- 시간표 이름 20자 제한 기능 -> 시간표 이름 입력 화면, 시간표 수정 화면 적용

## 📸 스크린샷
|스크린샷|
|:--:|
|![1](https://github.com/user-attachments/assets/c4912e3b-9903-4a40-a69e-14327514daf1)|
|![2](https://github.com/user-attachments/assets/60961551-bfc3-4c40-88f4-3943b2835233)|


## 📮 관련 이슈
- Resolved: #30 

### RCA 룰을 사용하여 코드 리뷰를 해주세요
`R (Request Changes)` : 적극적으로 반영을 고려해주세요   
`C (Comment)` : 웬만하면 반영해주세요   
`A (Approve)` : 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 시간표 이름이 20자를 초과하면 텍스트 필드에 에러 상태와 안내 문구를 표시
  - 텍스트 필드가 에러 상태 표시(isError)를 지원

- **버그 수정**
  - 뒤로가기 버튼의 터치 동작 일관성 개선
  - 시간표 이름 입력/편집 화면의 버튼 활성화 로직이 검증 규칙을 따르도록 수정
  - 시간표 목록의 빈 상태 문구와 배치(패딩) 조정으로 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->