### PR TITLE
feat: JWT 토큰 암호화 저장 및 검증 로그 추가

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,6 +99,8 @@ kotlin {
       implementation(libs.ktor.client.content.negotiation)
       implementation(libs.ktor.serialization.kotlinx.json)
       implementation(libs.ktor.client.logging)
+
+      implementation(libs.ksafe)
     }
     commonTest.dependencies {
       implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/di/AndroidModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/di/AndroidModule.kt
@@ -1,6 +1,7 @@
 package com.chukchukhaksa.mobile.di
 
 import com.chukchukhaksa.mobile.common.kmp.KakaoSignInClient
+import eu.anifantakis.lib.ksafe.KSafe
 import com.chukchukhaksa.mobile.local.database.openlecture.database.OpenLectureDatabaseFactory
 import com.chukchukhaksa.mobile.local.database.openmajor.database.OpenMajorDatabaseFactory
 import com.chukchukhaksa.mobile.local.database.timetable.database.TimetableDatabaseFactory
@@ -14,4 +15,5 @@ actual val platformModule = module {
     single { OpenLectureDatabaseFactory(androidApplication()) }
     single { ChukChukHaksaDataStoreFactory(androidApplication()) }
     factory { KakaoSignInClient() }
+    single { KSafe(androidApplication()) }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/datasource/LocalAuthDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/datasource/LocalAuthDataSource.kt
@@ -1,0 +1,9 @@
+package com.chukchukhaksa.mobile.data.auth.datasource
+
+interface LocalAuthDataSource {
+    suspend fun saveAccessToken(token: String)
+    suspend fun getAccessToken(): String?
+    suspend fun saveRefreshToken(token: String)
+    suspend fun getRefreshToken(): String?
+    suspend fun clearTokens()
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/di/AuthRepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/di/AuthRepositoryModule.kt
@@ -8,5 +8,5 @@ import org.koin.dsl.module
 
 val authRepositoryModule = module {
     single<RemoteAuthDataSource> { RemoteAuthDataSourceImpl(get()) }
-    single<AuthRepository> { AuthRepositoryImpl(get()) }
+    single<AuthRepository> { AuthRepositoryImpl(get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/repository/AuthRepositoryImpl.kt
@@ -1,14 +1,33 @@
 package com.chukchukhaksa.mobile.data.auth.repository
 
+import com.chukchukhaksa.mobile.data.auth.datasource.LocalAuthDataSource
 import com.chukchukhaksa.mobile.data.auth.datasource.RemoteAuthDataSource
 import com.chukchukhaksa.mobile.domain.auth.model.SignInResult
 import com.chukchukhaksa.mobile.domain.auth.repository.AuthRepository
 
 class AuthRepositoryImpl(
     private val remoteAuthDataSource: RemoteAuthDataSource,
+    private val localAuthDataSource: LocalAuthDataSource,
 ) : AuthRepository {
 
     override suspend fun signIn(idToken: String, nonce: String): SignInResult {
         return remoteAuthDataSource.signIn(idToken = idToken, nonce = nonce)
+    }
+
+    override suspend fun saveTokens(accessToken: String, refreshToken: String) {
+        localAuthDataSource.saveAccessToken(accessToken)
+        localAuthDataSource.saveRefreshToken(refreshToken)
+    }
+
+    override suspend fun getAccessToken(): String? {
+        return localAuthDataSource.getAccessToken()
+    }
+
+    override suspend fun getRefreshToken(): String? {
+        return localAuthDataSource.getRefreshToken()
+    }
+
+    override suspend fun clearTokens() {
+        localAuthDataSource.clearTokens()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
@@ -10,6 +10,7 @@ import com.chukchukhaksa.mobile.local.database.common.di.openMajorDatabaseModule
 import com.chukchukhaksa.mobile.local.database.common.di.timetableDatabaseModule
 import com.chukchukhaksa.mobile.local.datasource.openlecture.di.localOpenLectureDataSourceModule
 import com.chukchukhaksa.mobile.local.datasource.openmajor.di.localOpenMajorDataSourceModule
+import com.chukchukhaksa.mobile.local.datasource.auth.di.localAuthDataSourceModule
 import com.chukchukhaksa.mobile.local.datasource.timetable.di.localTimetableDataSourceModule
 import com.chukchukhaksa.mobile.local.datastore.di.dataStoreModule
 import com.chukchukhaksa.mobile.remote.config.remoteAppConfigDataSourceModule
@@ -41,6 +42,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             httpClientModule,
             remoteAppConfigDataSourceModule,
             appConfigRepositoryModule,
+            localAuthDataSourceModule,
             authRepositoryModule,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/repository/AuthRepository.kt
@@ -4,4 +4,8 @@ import com.chukchukhaksa.mobile.domain.auth.model.SignInResult
 
 interface AuthRepository {
     suspend fun signIn(idToken: String, nonce: String): SignInResult
+    suspend fun saveTokens(accessToken: String, refreshToken: String)
+    suspend fun getAccessToken(): String?
+    suspend fun getRefreshToken(): String?
+    suspend fun clearTokens()
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/KakaoLoginUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/KakaoLoginUseCase.kt
@@ -12,9 +12,14 @@ class KakaoLoginUseCase(
     suspend operator fun invoke(context: Any? = null): Result<SignInResult> =
         runCatchingIgnoreCancelled {
             val kakaoResult = kakaoSignInClient.signIn(context)
-            authRepository.signIn(
+            val signInResult = authRepository.signIn(
                 idToken = kakaoResult.idToken,
                 nonce = kakaoResult.nonce,
             )
+            authRepository.saveTokens(
+                accessToken = signInResult.accessToken,
+                refreshToken = signInResult.refreshToken,
+            )
+            signInResult
         }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/auth/datasource/LocalAuthDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/auth/datasource/LocalAuthDataSourceImpl.kt
@@ -1,0 +1,35 @@
+package com.chukchukhaksa.mobile.local.datasource.auth.datasource
+
+import com.chukchukhaksa.mobile.data.auth.datasource.LocalAuthDataSource
+import eu.anifantakis.lib.ksafe.KSafe
+
+class LocalAuthDataSourceImpl(
+    private val ksafe: KSafe,
+) : LocalAuthDataSource {
+
+    override suspend fun saveAccessToken(token: String) {
+        ksafe.put(KEY_ACCESS_TOKEN, token, encrypted = true)
+    }
+
+    override suspend fun getAccessToken(): String? {
+        return ksafe.get(KEY_ACCESS_TOKEN, "", encrypted = true).ifEmpty { null }
+    }
+
+    override suspend fun saveRefreshToken(token: String) {
+        ksafe.put(KEY_REFRESH_TOKEN, token, encrypted = true)
+    }
+
+    override suspend fun getRefreshToken(): String? {
+        return ksafe.get(KEY_REFRESH_TOKEN, "", encrypted = true).ifEmpty { null }
+    }
+
+    override suspend fun clearTokens() {
+        ksafe.delete(KEY_ACCESS_TOKEN)
+        ksafe.delete(KEY_REFRESH_TOKEN)
+    }
+
+    companion object {
+        private const val KEY_ACCESS_TOKEN = "auth_access_token"
+        private const val KEY_REFRESH_TOKEN = "auth_refresh_token"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/auth/di/LocalAuthDataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/auth/di/LocalAuthDataSourceModule.kt
@@ -1,0 +1,9 @@
+package com.chukchukhaksa.mobile.local.datasource.auth.di
+
+import com.chukchukhaksa.mobile.data.auth.datasource.LocalAuthDataSource
+import com.chukchukhaksa.mobile.local.datasource.auth.datasource.LocalAuthDataSourceImpl
+import org.koin.dsl.module
+
+val localAuthDataSourceModule = module {
+    single<LocalAuthDataSource> { LocalAuthDataSourceImpl(get()) }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/WebViewGuideScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/timetable/component/WebViewGuideScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/di/IosModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/di/IosModule.kt
@@ -2,6 +2,7 @@ package com.chukchukhaksa.mobile.di
 
 import com.chukchukhaksa.mobile.common.kmp.AppleSignInClient
 import com.chukchukhaksa.mobile.common.kmp.KakaoSignInClient
+import eu.anifantakis.lib.ksafe.KSafe
 import com.chukchukhaksa.mobile.local.database.openlecture.database.OpenLectureDatabaseFactory
 import com.chukchukhaksa.mobile.local.database.openmajor.database.OpenMajorDatabaseFactory
 import com.chukchukhaksa.mobile.local.database.timetable.database.TimetableDatabaseFactory
@@ -16,4 +17,5 @@ actual val platformModule
         single { ChukChukHaksaDataStoreFactory() }
         factory { AppleSignInClient() }
         factory { KakaoSignInClient(get()) }
+        single { KSafe() }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ composeRuntime = "1.10.0"
 ktor = "3.3.1"
 kakao-sdk = "2.20.6"
 kinappbrowser = "1.0.0"
+ksafe = "1.6.0"
 
 
 [libraries]
@@ -98,6 +99,8 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 kakao-sdk-v2-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-sdk" }
 
 kinappbrowser = { group = "dev.yjyoon", name = "kinappbrowser", version.ref = "kinappbrowser" }
+
+ksafe = { group = "eu.anifantakis", name = "ksafe", version.ref = "ksafe" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
KSafe 라이브러리를 활용한 암호화 토큰 저장소 구현 및
카카오 로그인 시 토큰 저장/조회 검증 로그 추가

## 📌 PR 요약

🌱 작업한 내용
- 

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #72

### RCA 룰을 사용하여 코드 리뷰를 해주세요
`R (Request Changes)` : 적극적으로 반영을 고려해주세요   
`C (Comment)` : 웬만하면 반영해주세요   
`A (Approve)` : 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **새로운 기능**
  * 인증 토큰이 안전하게 로컬에 저장되어 사용자가 앱 재시작 후에도 로그인 상태를 유지할 수 있습니다.

* **개선사항**
  * 인증 토큰의 저장, 조회, 초기화 기능이 추가되었습니다.
  * 플랫폼별 보안 저장소 구현으로 인증 데이터 보호 수준이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->