### PR TITLE
feat: Apple 로그인 서버 인증 및 토큰 자동 리프레시 구현

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -100,12 +100,14 @@ kotlin {
       implementation(libs.ktor.client.content.negotiation)
       implementation(libs.ktor.serialization.kotlinx.json)
       implementation(libs.ktor.client.logging)
+      implementation(libs.ktor.client.auth)
 
       implementation(libs.ksafe)
     }
     commonTest.dependencies {
       implementation(libs.kotlin.test)
       implementation(libs.kotlinx.coroutines.test)
+      implementation(libs.ktor.client.mock)
     }
   }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/MainViewModel.kt
@@ -66,7 +66,7 @@ class MainViewModel(
             is NetworkException -> { mviStore.setState { copy(showNetworkErrorDialog = true) } }
 //            is ConnectException -> { mviStore.setState { copy(showNetworkErrorDialog = true) } }
             else -> {
-                onShowToast(throwable.message ?: UnknownException().message)
+                onShowToast("네트워크 오류가 발생했습니다.")
                 throwable.record()
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/AppleSignInClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/AppleSignInClient.kt
@@ -6,6 +6,7 @@ data class AppleSignInResult(
     val userId: String,
     val email: String?,
     val fullName: String?,
+    val nonce: String,
 )
 
 expect class AppleSignInClient() {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/datasource/RemoteAuthDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/datasource/RemoteAuthDataSource.kt
@@ -4,6 +4,6 @@ import com.chukchukhaksa.mobile.domain.auth.model.RefreshTokenResult
 import com.chukchukhaksa.mobile.domain.auth.model.SignInResult
 
 interface RemoteAuthDataSource {
-    suspend fun signIn(idToken: String, nonce: String): SignInResult
+    suspend fun signIn(provider: String, idToken: String, nonce: String): SignInResult
     suspend fun refreshToken(refreshToken: String): RefreshTokenResult
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/auth/repository/AuthRepositoryImpl.kt
@@ -10,8 +10,8 @@ class AuthRepositoryImpl(
     private val localAuthDataSource: LocalAuthDataSource,
 ) : AuthRepository {
 
-    override suspend fun signIn(idToken: String, nonce: String): SignInResult {
-        return remoteAuthDataSource.signIn(idToken = idToken, nonce = nonce)
+    override suspend fun signIn(provider: String, idToken: String, nonce: String): SignInResult {
+        return remoteAuthDataSource.signIn(provider = provider, idToken = idToken, nonce = nonce)
     }
 
     override suspend fun refreshToken() {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DomainModules.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DomainModules.kt
@@ -45,7 +45,7 @@ val domainModule = module {
     factory { CheckNeedForceUpdateUseCase(get())}
 
     // Auth use cases
-    factory { AppleLoginUseCase(get()) }
+    factory { AppleLoginUseCase(get(), get()) }
     factory { CheckAuthStateUseCase(get()) }
     factory { KakaoLoginUseCase(get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/repository/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.chukchukhaksa.mobile.domain.auth.repository
 import com.chukchukhaksa.mobile.domain.auth.model.SignInResult
 
 interface AuthRepository {
-    suspend fun signIn(idToken: String, nonce: String): SignInResult
+    suspend fun signIn(provider: String, idToken: String, nonce: String): SignInResult
     suspend fun refreshToken()
     suspend fun saveTokens(accessToken: String, refreshToken: String)
     suspend fun getAccessToken(): String?

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/AppleLoginUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/AppleLoginUseCase.kt
@@ -1,13 +1,25 @@
 package com.chukchukhaksa.mobile.domain.auth.usecase
 
-import com.chukchukhaksa.mobile.common.kmp.AppleSignInResult
 import com.chukchukhaksa.mobile.common.kmp.AppleSignInClient
+import com.chukchukhaksa.mobile.domain.auth.model.SignInResult
+import com.chukchukhaksa.mobile.domain.auth.repository.AuthRepository
 import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
 
 class AppleLoginUseCase(
     private val appleSignInClient: AppleSignInClient,
+    private val authRepository: AuthRepository,
 ) {
-    suspend operator fun invoke(): Result<AppleSignInResult> = runCatchingIgnoreCancelled {
-        appleSignInClient.signIn()
+    suspend operator fun invoke(): Result<SignInResult> = runCatchingIgnoreCancelled {
+        val appleResult = appleSignInClient.signIn()
+        val signInResult = authRepository.signIn(
+            provider = "APPLE",
+            idToken = appleResult.identityToken,
+            nonce = appleResult.nonce,
+        )
+        authRepository.saveTokens(
+            accessToken = signInResult.accessToken,
+            refreshToken = signInResult.refreshToken,
+        )
+        signInResult
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/KakaoLoginUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/auth/usecase/KakaoLoginUseCase.kt
@@ -13,6 +13,7 @@ class KakaoLoginUseCase(
         runCatchingIgnoreCancelled {
             val kakaoResult = kakaoSignInClient.signIn(context)
             val signInResult = authRepository.signIn(
+                provider = "KAKAO",
                 idToken = kakaoResult.idToken,
                 nonce = kakaoResult.nonce,
             )

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/landing/LandingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/landing/LandingScreen.kt
@@ -130,7 +130,7 @@ fun LandingScreen(
                     iconRes = Res.drawable.ic_apple_logo,
                     containerColor = Black100,
                     contentColor = White100,
-                    enabled = true,
+                    enabled = !uiState.isLoading,
                     onClick = onAppleLogin,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/landing/LandingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/landing/LandingViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chukchukhaksa.mobile.common.ui.MviStore
 import com.chukchukhaksa.mobile.common.ui.mviStore
+import com.chukchukhaksa.mobile.domain.auth.usecase.AppleLoginUseCase
 import com.chukchukhaksa.mobile.domain.auth.usecase.KakaoLoginUseCase
 import kotlinx.coroutines.launch
 
 class LandingViewModel(
     private val kakaoLoginUseCase: KakaoLoginUseCase,
+    private val appleLoginUseCase: AppleLoginUseCase,
 ) : ViewModel() {
 
     val mviStore: MviStore<LandingState, LandingSideEffect> = mviStore(LandingState())
@@ -33,6 +35,21 @@ class LandingViewModel(
     }
 
     fun onAppleLogin() {
-        mviStore.postSideEffect(LandingSideEffect.ShowToast("준비 중입니다"))
+        if (mviStore.uiState.value.isLoading) return
+        mviStore.setState { copy(isLoading = true) }
+
+        viewModelScope.launch {
+            try {
+                appleLoginUseCase()
+                    .onSuccess {
+                        mviStore.postSideEffect(LandingSideEffect.NavigateHome)
+                    }
+                    .onFailure { throwable ->
+                        mviStore.postSideEffect(LandingSideEffect.HandleException(throwable))
+                    }
+            } finally {
+                mviStore.setState { copy(isLoading = false) }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/AuthEventBus.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/AuthEventBus.kt
@@ -1,0 +1,18 @@
+package com.chukchukhaksa.mobile.remote.auth
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class AuthEventBus {
+    private val _events = MutableSharedFlow<AuthEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AuthEvent> = _events.asSharedFlow()
+
+    fun emit(event: AuthEvent = AuthEvent.TokenExpired) {
+        _events.tryEmit(event)
+    }
+}
+
+sealed interface AuthEvent {
+    data object TokenExpired : AuthEvent
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/RemoteAuthDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/RemoteAuthDataSourceImpl.kt
@@ -18,9 +18,9 @@ class RemoteAuthDataSourceImpl(
     private val httpClient: HttpClient,
 ) : RemoteAuthDataSource {
 
-    override suspend fun signIn(idToken: String, nonce: String): SignInResult {
+    override suspend fun signIn(provider: String, idToken: String, nonce: String): SignInResult {
         val response = httpClient.post("users/signin") {
-            setBody(SignInRequest(idToken = idToken, nonce = nonce))
+            setBody(SignInRequest(provider = provider, idToken = idToken, nonce = nonce))
         }.body<ApiResponse<SignInResponse>>()
 
         return response.getDataOrThrow().toSignInResult()

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/model/SignInRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/auth/model/SignInRequest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SignInRequest(
+    val provider: String,
     @SerialName("id_token") val idToken: String,
     val nonce: String,
 )

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
@@ -46,7 +46,7 @@ private fun String.prettyPrintJson(): String = try {
 
 private val BASE_URL = if (isDebug) "https://dev.api.cchaksa.com/api/" else "https://api.cchaksa.com/api/"
 
-private val AUTH_EXCLUDED_PATHS = listOf(
+internal val AUTH_EXCLUDED_PATHS = listOf(
     "auth/refresh",
     "users/signin",
 )
@@ -59,6 +59,11 @@ val httpClientModule = module {
         val authEventBus: AuthEventBus = get()
 
         val refreshClient = HttpClient(httpClientEngineFactory) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 10_000
+                connectTimeoutMillis = 5_000
+                socketTimeoutMillis = 10_000
+            }
             install(ContentNegotiation) {
                 json(
                     Json {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
@@ -14,6 +14,7 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.AuthConfig
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -50,6 +51,56 @@ internal val AUTH_EXCLUDED_PATHS = listOf(
     "auth/refresh",
     "users/signin",
 )
+
+internal fun AuthConfig.configureBearerAuth(
+    localAuthDataSource: LocalAuthDataSource,
+    authEventBus: AuthEventBus,
+    refreshClient: HttpClient,
+) {
+    bearer {
+        loadTokens {
+            val accessToken = localAuthDataSource.getAccessToken()
+            val refreshToken = localAuthDataSource.getRefreshToken()
+            if (accessToken != null && refreshToken != null) {
+                BearerTokens(accessToken, refreshToken)
+            } else {
+                null
+            }
+        }
+
+        refreshTokens {
+            val currentRefreshToken = localAuthDataSource.getRefreshToken()
+            if (currentRefreshToken == null) {
+                localAuthDataSource.clearTokens()
+                authEventBus.emit()
+                return@refreshTokens null
+            }
+
+            try {
+                val response = refreshClient.post("auth/refresh") {
+                    setBody(RefreshRequest(refreshToken = currentRefreshToken))
+                }.body<ApiResponse<RefreshResponse>>()
+
+                val result = response.getDataOrThrow()
+                localAuthDataSource.saveAccessToken(result.accessToken)
+                localAuthDataSource.saveRefreshToken(result.refreshToken)
+                BearerTokens(result.accessToken, result.refreshToken)
+            } catch (e: Exception) {
+                Napier.e("Token refresh failed", e)
+                localAuthDataSource.clearTokens()
+                authEventBus.emit()
+                null
+            }
+        }
+
+        sendWithoutRequest { request ->
+            val requestPath = request.url.pathSegments.joinToString("/")
+            AUTH_EXCLUDED_PATHS.none { path ->
+                requestPath.contains(path)
+            }
+        }
+    }
+}
 
 val httpClientModule = module {
     single { AuthEventBus() }
@@ -95,49 +146,7 @@ val httpClientModule = module {
             }
 
             install(Auth) {
-                bearer {
-                    loadTokens {
-                        val accessToken = localAuthDataSource.getAccessToken()
-                        val refreshToken = localAuthDataSource.getRefreshToken()
-                        if (accessToken != null && refreshToken != null) {
-                            BearerTokens(accessToken, refreshToken)
-                        } else {
-                            null
-                        }
-                    }
-
-                    refreshTokens {
-                        val currentRefreshToken = localAuthDataSource.getRefreshToken()
-                        if (currentRefreshToken == null) {
-                            localAuthDataSource.clearTokens()
-                            authEventBus.emit()
-                            return@refreshTokens null
-                        }
-
-                        try {
-                            val response = refreshClient.post("auth/refresh") {
-                                setBody(RefreshRequest(refreshToken = currentRefreshToken))
-                            }.body<ApiResponse<RefreshResponse>>()
-
-                            val result = response.getDataOrThrow()
-                            localAuthDataSource.saveAccessToken(result.accessToken)
-                            localAuthDataSource.saveRefreshToken(result.refreshToken)
-                            BearerTokens(result.accessToken, result.refreshToken)
-                        } catch (e: Exception) {
-                            Napier.e("Token refresh failed", e)
-                            localAuthDataSource.clearTokens()
-                            authEventBus.emit()
-                            null
-                        }
-                    }
-
-                    sendWithoutRequest { request ->
-                        val requestPath = request.url.pathSegments.joinToString("/")
-                        AUTH_EXCLUDED_PATHS.none { path ->
-                            requestPath.contains(path)
-                        }
-                    }
-                }
+                configureBearerAuth(localAuthDataSource, authEventBus, refreshClient)
             }
 
             install(Logging) {

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/di/HttpClientModule.kt
@@ -2,10 +2,20 @@ package com.chukchukhaksa.mobile.remote.di
 
 import com.chukchukhaksa.mobile.common.kmp.httpClientEngineFactory
 import com.chukchukhaksa.mobile.common.kmp.isDebug
+import com.chukchukhaksa.mobile.data.auth.datasource.LocalAuthDataSource
+import com.chukchukhaksa.mobile.remote.auth.AuthEventBus
+import com.chukchukhaksa.mobile.remote.auth.model.RefreshRequest
+import com.chukchukhaksa.mobile.remote.auth.model.RefreshResponse
+import com.chukchukhaksa.mobile.remote.common.ApiResponse
+import com.chukchukhaksa.mobile.remote.common.getDataOrThrow
 import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
@@ -13,6 +23,8 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.observer.ResponseObserver
 import io.ktor.client.plugins.plugin
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -32,8 +44,35 @@ private fun String.prettyPrintJson(): String = try {
     this
 }
 
+private val BASE_URL = if (isDebug) "https://dev.api.cchaksa.com/api/" else "https://api.cchaksa.com/api/"
+
+private val AUTH_EXCLUDED_PATHS = listOf(
+    "auth/refresh",
+    "users/signin",
+)
+
 val httpClientModule = module {
+    single { AuthEventBus() }
+
     single {
+        val localAuthDataSource: LocalAuthDataSource = get()
+        val authEventBus: AuthEventBus = get()
+
+        val refreshClient = HttpClient(httpClientEngineFactory) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    },
+                )
+            }
+            defaultRequest {
+                url(BASE_URL)
+                contentType(ContentType.Application.Json)
+            }
+        }
+
         HttpClient(httpClientEngineFactory) {
             install(HttpTimeout) {
                 requestTimeoutMillis = 15_000
@@ -48,6 +87,52 @@ val httpClientModule = module {
                         isLenient = true
                     },
                 )
+            }
+
+            install(Auth) {
+                bearer {
+                    loadTokens {
+                        val accessToken = localAuthDataSource.getAccessToken()
+                        val refreshToken = localAuthDataSource.getRefreshToken()
+                        if (accessToken != null && refreshToken != null) {
+                            BearerTokens(accessToken, refreshToken)
+                        } else {
+                            null
+                        }
+                    }
+
+                    refreshTokens {
+                        val currentRefreshToken = localAuthDataSource.getRefreshToken()
+                        if (currentRefreshToken == null) {
+                            localAuthDataSource.clearTokens()
+                            authEventBus.emit()
+                            return@refreshTokens null
+                        }
+
+                        try {
+                            val response = refreshClient.post("auth/refresh") {
+                                setBody(RefreshRequest(refreshToken = currentRefreshToken))
+                            }.body<ApiResponse<RefreshResponse>>()
+
+                            val result = response.getDataOrThrow()
+                            localAuthDataSource.saveAccessToken(result.accessToken)
+                            localAuthDataSource.saveRefreshToken(result.refreshToken)
+                            BearerTokens(result.accessToken, result.refreshToken)
+                        } catch (e: Exception) {
+                            Napier.e("Token refresh failed", e)
+                            localAuthDataSource.clearTokens()
+                            authEventBus.emit()
+                            null
+                        }
+                    }
+
+                    sendWithoutRequest { request ->
+                        val requestPath = request.url.pathSegments.joinToString("/")
+                        AUTH_EXCLUDED_PATHS.none { path ->
+                            requestPath.contains(path)
+                        }
+                    }
+                }
             }
 
             install(Logging) {
@@ -83,7 +168,7 @@ val httpClientModule = module {
             }
 
             defaultRequest {
-                url("https://api.cchaksa.com/api/")
+                url(BASE_URL)
                 contentType(ContentType.Application.Json)
             }
         }.also { client ->

--- a/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/FakeLocalAuthDataSource.kt
+++ b/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/FakeLocalAuthDataSource.kt
@@ -1,0 +1,28 @@
+package com.chukchukhaksa.mobile.remote.auth
+
+import com.chukchukhaksa.mobile.data.auth.datasource.LocalAuthDataSource
+
+class FakeLocalAuthDataSource(
+    initialAccessToken: String? = null,
+    initialRefreshToken: String? = null,
+) : LocalAuthDataSource {
+    private var accessToken: String? = initialAccessToken
+    private var refreshToken: String? = initialRefreshToken
+
+    override suspend fun saveAccessToken(token: String) {
+        accessToken = token
+    }
+
+    override suspend fun getAccessToken(): String? = accessToken
+
+    override suspend fun saveRefreshToken(token: String) {
+        refreshToken = token
+    }
+
+    override suspend fun getRefreshToken(): String? = refreshToken
+
+    override suspend fun clearTokens() {
+        accessToken = null
+        refreshToken = null
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
@@ -1,17 +1,11 @@
 package com.chukchukhaksa.mobile.remote.auth
 
-import com.chukchukhaksa.mobile.remote.auth.model.RefreshRequest
-import com.chukchukhaksa.mobile.remote.auth.model.RefreshResponse
-import com.chukchukhaksa.mobile.remote.common.ApiResponse
-import com.chukchukhaksa.mobile.remote.common.getDataOrThrow
+import com.chukchukhaksa.mobile.remote.di.configureBearerAuth
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.auth.Auth
-import io.ktor.client.plugins.auth.providers.BearerTokens
-import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestData
@@ -45,8 +39,6 @@ class TokenAuthIntegrationTest {
     }
 
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
-
-    private val AUTH_EXCLUDED_PATHS = com.chukchukhaksa.mobile.remote.di.AUTH_EXCLUDED_PATHS
 
     // --- JSON Response Helpers ---
 
@@ -94,48 +86,7 @@ class TokenAuthIntegrationTest {
             install(ContentNegotiation) { json(json) }
 
             install(Auth) {
-                bearer {
-                    loadTokens {
-                        val access = fakeDataSource.getAccessToken()
-                        val refresh = fakeDataSource.getRefreshToken()
-                        if (access != null && refresh != null) {
-                            BearerTokens(access, refresh)
-                        } else {
-                            null
-                        }
-                    }
-
-                    refreshTokens {
-                        val currentRefresh = fakeDataSource.getRefreshToken()
-                        if (currentRefresh == null) {
-                            fakeDataSource.clearTokens()
-                            authEventBus.emit()
-                            return@refreshTokens null
-                        }
-
-                        try {
-                            val response = refreshClient.post("auth/refresh") {
-                                setBody(RefreshRequest(refreshToken = currentRefresh))
-                            }.body<ApiResponse<RefreshResponse>>()
-
-                            val result = response.getDataOrThrow()
-                            fakeDataSource.saveAccessToken(result.accessToken)
-                            fakeDataSource.saveRefreshToken(result.refreshToken)
-                            BearerTokens(result.accessToken, result.refreshToken)
-                        } catch (e: Exception) {
-                            fakeDataSource.clearTokens()
-                            authEventBus.emit()
-                            null
-                        }
-                    }
-
-                    sendWithoutRequest { request ->
-                        val requestPath = request.url.pathSegments.joinToString("/")
-                        AUTH_EXCLUDED_PATHS.none { path ->
-                            requestPath.contains(path)
-                        }
-                    }
-                }
+                configureBearerAuth(fakeDataSource, authEventBus, refreshClient)
             }
 
             defaultRequest {

--- a/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
@@ -1,0 +1,345 @@
+package com.chukchukhaksa.mobile.remote.auth
+
+import com.chukchukhaksa.mobile.remote.auth.model.RefreshRequest
+import com.chukchukhaksa.mobile.remote.auth.model.RefreshResponse
+import com.chukchukhaksa.mobile.remote.common.ApiResponse
+import com.chukchukhaksa.mobile.remote.common.getDataOrThrow
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TokenAuthIntegrationTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+    private val AUTH_EXCLUDED_PATHS = listOf(
+        "auth/refresh",
+        "users/signin",
+    )
+
+    // --- JSON Response Helpers ---
+
+    private fun MockRequestHandleScope.jsonResponse(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ) = respond(
+        content = body,
+        status = status,
+        headers = jsonHeaders,
+    )
+
+    private fun successApiResponse(): String =
+        """{"success":true,"data":"ok"}"""
+
+    private fun errorApiResponse(
+        code: String = "T04",
+        message: String = "만료된 토큰입니다.",
+    ): String =
+        """{"success":false,"data":null,"error":{"code":"$code","message":"$message"}}"""
+
+    private fun refreshSuccessResponse(
+        accessToken: String = "new-access-token",
+        refreshToken: String = "new-refresh-token",
+    ): String =
+        """{"success":true,"data":{"accessToken":"$accessToken","refreshToken":"$refreshToken"}}"""
+
+    // --- Test HttpClient Factory ---
+
+    private fun buildTestClient(
+        fakeDataSource: FakeLocalAuthDataSource,
+        authEventBus: AuthEventBus,
+        mainEngine: MockEngine,
+        refreshEngine: MockEngine,
+    ): HttpClient {
+        val refreshClient = HttpClient(refreshEngine) {
+            install(ContentNegotiation) { json(json) }
+            defaultRequest {
+                url("https://api.test.com/api/")
+                contentType(ContentType.Application.Json)
+            }
+        }
+
+        return HttpClient(mainEngine) {
+            install(ContentNegotiation) { json(json) }
+
+            install(Auth) {
+                bearer {
+                    loadTokens {
+                        val access = fakeDataSource.getAccessToken()
+                        val refresh = fakeDataSource.getRefreshToken()
+                        if (access != null && refresh != null) {
+                            BearerTokens(access, refresh)
+                        } else {
+                            null
+                        }
+                    }
+
+                    refreshTokens {
+                        val currentRefresh = fakeDataSource.getRefreshToken()
+                        if (currentRefresh == null) {
+                            fakeDataSource.clearTokens()
+                            authEventBus.emit()
+                            return@refreshTokens null
+                        }
+
+                        try {
+                            val response = refreshClient.post("auth/refresh") {
+                                setBody(RefreshRequest(refreshToken = currentRefresh))
+                            }.body<ApiResponse<RefreshResponse>>()
+
+                            val result = response.getDataOrThrow()
+                            fakeDataSource.saveAccessToken(result.accessToken)
+                            fakeDataSource.saveRefreshToken(result.refreshToken)
+                            BearerTokens(result.accessToken, result.refreshToken)
+                        } catch (e: Exception) {
+                            fakeDataSource.clearTokens()
+                            authEventBus.emit()
+                            null
+                        }
+                    }
+
+                    sendWithoutRequest { request ->
+                        val requestPath = request.url.pathSegments.joinToString("/")
+                        AUTH_EXCLUDED_PATHS.none { path ->
+                            requestPath.contains(path)
+                        }
+                    }
+                }
+            }
+
+            defaultRequest {
+                url("https://api.test.com/api/")
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
+
+    // --- 토큰 자동 첨부 테스트 ---
+
+    @Test
+    fun `토큰이 있으면 Authorization 헤더에 Bearer 토큰이 포함된다`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource(
+            initialAccessToken = "valid-access-token",
+            initialRefreshToken = "valid-refresh-token",
+        )
+        val authEventBus = AuthEventBus()
+        val requestLog = mutableListOf<HttpRequestData>()
+
+        val mainEngine = MockEngine { request ->
+            requestLog.add(request)
+            jsonResponse(successApiResponse())
+        }
+        val refreshEngine = MockEngine { jsonResponse(successApiResponse()) }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+        client.get("timetable")
+
+        assertEquals(1, requestLog.size)
+        assertEquals(
+            "Bearer valid-access-token",
+            requestLog[0].headers[HttpHeaders.Authorization],
+        )
+    }
+
+    @Test
+    fun `토큰이 없으면 Authorization 헤더가 포함되지 않는다`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource()
+        val authEventBus = AuthEventBus()
+        val requestLog = mutableListOf<HttpRequestData>()
+
+        val mainEngine = MockEngine { request ->
+            requestLog.add(request)
+            jsonResponse(successApiResponse())
+        }
+        val refreshEngine = MockEngine { jsonResponse(successApiResponse()) }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+        client.get("timetable")
+
+        assertEquals(1, requestLog.size)
+        assertNull(requestLog[0].headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `인증 제외 경로에는 Authorization 헤더가 포함되지 않는다`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource(
+            initialAccessToken = "valid-access-token",
+            initialRefreshToken = "valid-refresh-token",
+        )
+        val authEventBus = AuthEventBus()
+        val requestLog = mutableListOf<HttpRequestData>()
+
+        val mainEngine = MockEngine { request ->
+            requestLog.add(request)
+            jsonResponse(successApiResponse())
+        }
+        val refreshEngine = MockEngine { jsonResponse(successApiResponse()) }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+        client.post("users/signin") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"idToken":"test","nonce":"test"}""")
+        }
+
+        assertEquals(1, requestLog.size)
+        assertNull(requestLog[0].headers[HttpHeaders.Authorization])
+    }
+
+    // --- 토큰 리프레시 + 재시도 테스트 ---
+
+    @Test
+    fun `401 응답 시 토큰 리프레시 후 새 토큰으로 재시도한다`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource(
+            initialAccessToken = "expired-access-token",
+            initialRefreshToken = "valid-refresh-token",
+        )
+        val authEventBus = AuthEventBus()
+        val requestLog = mutableListOf<HttpRequestData>()
+
+        val mainEngine = MockEngine { request ->
+            requestLog.add(request)
+            val authHeader = request.headers[HttpHeaders.Authorization]
+            if (authHeader == "Bearer expired-access-token") {
+                jsonResponse(errorApiResponse(), HttpStatusCode.Unauthorized)
+            } else {
+                jsonResponse(successApiResponse())
+            }
+        }
+
+        val refreshLog = mutableListOf<HttpRequestData>()
+        val refreshEngine = MockEngine { request ->
+            refreshLog.add(request)
+            jsonResponse(refreshSuccessResponse())
+        }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+        val response = client.get("timetable")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        // 원래 요청(401) + 재시도(200) = 2번
+        assertEquals(2, requestLog.size)
+        assertEquals(
+            "Bearer expired-access-token",
+            requestLog[0].headers[HttpHeaders.Authorization],
+        )
+        assertEquals(
+            "Bearer new-access-token",
+            requestLog[1].headers[HttpHeaders.Authorization],
+        )
+        // 리프레시 1회 호출
+        assertEquals(1, refreshLog.size)
+        // 새 토큰이 로컬에 저장됨
+        assertEquals("new-access-token", fakeDataSource.getAccessToken())
+        assertEquals("new-refresh-token", fakeDataSource.getRefreshToken())
+    }
+
+    // --- 리프레시 실패 테스트 ---
+
+    @Test
+    fun `리프레시 실패 시 토큰 삭제 및 인증 만료 이벤트 발행`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource(
+            initialAccessToken = "expired-access-token",
+            initialRefreshToken = "expired-refresh-token",
+        )
+        val authEventBus = AuthEventBus()
+
+        val events = mutableListOf<AuthEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            authEventBus.events.collect { events.add(it) }
+        }
+
+        val mainEngine = MockEngine {
+            jsonResponse(errorApiResponse(), HttpStatusCode.Unauthorized)
+        }
+        val refreshEngine = MockEngine {
+            jsonResponse(errorApiResponse(), HttpStatusCode.Unauthorized)
+        }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+        val response = client.get("timetable")
+
+        // 최종 응답은 401
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        // 토큰이 삭제됨
+        assertNull(fakeDataSource.getAccessToken())
+        assertNull(fakeDataSource.getRefreshToken())
+        // 인증 만료 이벤트 발행됨
+        assertTrue(events.any { it is AuthEvent.TokenExpired })
+    }
+
+    // --- 동시 요청 리프레시 테스트 ---
+
+    @Test
+    fun `동시 요청 시 리프레시는 1회만 수행된다`() = runTest {
+        val fakeDataSource = FakeLocalAuthDataSource(
+            initialAccessToken = "expired-access-token",
+            initialRefreshToken = "valid-refresh-token",
+        )
+        val authEventBus = AuthEventBus()
+
+        val mainEngine = MockEngine { request ->
+            val authHeader = request.headers[HttpHeaders.Authorization]
+            if (authHeader == "Bearer expired-access-token") {
+                jsonResponse(errorApiResponse(), HttpStatusCode.Unauthorized)
+            } else {
+                jsonResponse(successApiResponse())
+            }
+        }
+
+        val refreshLog = mutableListOf<HttpRequestData>()
+        val refreshEngine = MockEngine { request ->
+            refreshLog.add(request)
+            jsonResponse(refreshSuccessResponse())
+        }
+
+        val client = buildTestClient(fakeDataSource, authEventBus, mainEngine, refreshEngine)
+
+        val results = (1..3).map {
+            async { client.get("timetable") }
+        }.awaitAll()
+
+        // 모든 요청이 성공
+        results.forEach { response ->
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+        // 리프레시는 1회만 수행
+        assertEquals(1, refreshLog.size)
+        // 새 토큰이 저장됨
+        assertEquals("new-access-token", fakeDataSource.getAccessToken())
+        assertEquals("new-refresh-token", fakeDataSource.getRefreshToken())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/chukchukhaksa/mobile/remote/auth/TokenAuthIntegrationTest.kt
@@ -46,10 +46,7 @@ class TokenAuthIntegrationTest {
 
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
 
-    private val AUTH_EXCLUDED_PATHS = listOf(
-        "auth/refresh",
-        "users/signin",
-    )
+    private val AUTH_EXCLUDED_PATHS = com.chukchukhaksa.mobile.remote.di.AUTH_EXCLUDED_PATHS
 
     // --- JSON Response Helpers ---
 

--- a/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/AppleSignInClient.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/AppleSignInClient.ios.kt
@@ -16,6 +16,7 @@ import platform.AuthenticationServices.ASPresentationAnchor
 import platform.Foundation.NSError
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.NSUUID
 import platform.Foundation.create
 import platform.UIKit.UIApplication
 import platform.UIKit.UIWindow
@@ -31,7 +32,10 @@ actual class AppleSignInClient actual constructor() {
     private var currentController: ASAuthorizationController? = null
 
     actual suspend fun signIn(): AppleSignInResult = suspendCancellableCoroutine { continuation ->
-        val delegate = AppleSignInDelegate(continuation) {
+        val rawNonce = NSUUID().UUIDString()
+        val hashedNonce = sha256Hex(rawNonce)
+
+        val delegate = AppleSignInDelegate(continuation, rawNonce) {
             currentDelegate = null
             currentController = null
         }
@@ -43,6 +47,7 @@ actual class AppleSignInClient actual constructor() {
             ASAuthorizationScopeEmail,
             ASAuthorizationScopeFullName,
         )
+        request.nonce = hashedNonce
 
         val controller = ASAuthorizationController(
             authorizationRequests = listOf(request),
@@ -62,6 +67,7 @@ actual class AppleSignInClient actual constructor() {
 
 private class AppleSignInDelegate(
     private val continuation: CancellableContinuation<AppleSignInResult>,
+    private val rawNonce: String,
     private val onComplete: () -> Unit,
 ) : NSObject(),
     ASAuthorizationControllerDelegateProtocol,
@@ -129,6 +135,7 @@ private class AppleSignInDelegate(
                 userId = credential.user,
                 email = credential.email,
                 fullName = fullName,
+                nonce = rawNonce,
             ),
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,6 +96,8 @@ ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.r
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 kakao-sdk-v2-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-sdk" }
 


### PR DESCRIPTION
## 요약

Apple 로그인의 서버 인증 연동과 provider 기반 로그인 분기를 구현하고, Ktor Auth 플러그인을 활용한 토큰 자동 첨부 및 리프레시 기능을 추가했습니다. 통합 테스트를 통해 토큰 만료/갱신 시나리오를 검증합니다.

resolve: #48 

## 변경 사항

### Features
- `feat: Ktor Auth 플러그인 기반 토큰 자동 첨부/리프레시 및 통합 테스트 구현`
- `feat: Apple 로그인 서버 인증 연동 및 provider 기반 로그인 분기 구현`

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인 흐름을 실제 인증 서버와 연동해 동작하도록 개선하고, 인증 만료 시 자동 토큰 갱신 및 관련 이벤트 발행을 추가했습니다.

* **버그 수정**
  * 네트워크 오류 토스트 메시지를 통일했습니다.
  * 소셜 로그인 버튼이 로딩 중 비활성화되도록 수정했습니다.

* **테스트**
  * 토큰 인증/갱신 동작을 검증하는 통합 테스트와 테스트용 로컬 인증 더미를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->